### PR TITLE
修正子图标题大小与其他标题大小一致

### DIFF
--- a/buptthesis.cls
+++ b/buptthesis.cls
@@ -165,7 +165,7 @@
   \RequirePackage{graphicx}
   %% In fact, the xunicode package has loaded the graphicx package.
 \fi
-\RequirePackage[font=footnotesize,subrefformat=parens]{subfig}
+\RequirePackage[font=small,subrefformat=parens]{subfig}
 
 %% Table and Array Packages
 \RequirePackage{makecell}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1b6007fd-987e-42a8-8e41-bb21517ab9f0)

根据word模板，子图标题大小与其他标题大小一致，均为五号，所以修改subfig导入设置，将subfig宏包导入时的字体大小设置为small，与普通caption的大小一致

`\RequirePackage[font=small,subrefformat=parens]{subfig}`
